### PR TITLE
Solving issue with `/` in the wildcards

### DIFF
--- a/{{cookiecutter.profile_name}}/lsf-submit.py
+++ b/{{cookiecutter.profile_name}}/lsf-submit.py
@@ -66,15 +66,17 @@ def get_job_name(job_properties: dict) -> str:
 
 def generate_jobinfo_command(job_properties: dict) -> str:
     log_dir = Path(cluster.get("logdir", "{{cookiecutter.default_cluster_logdir}}"))
-
-    if not log_dir.absolute().exists():
-        raise NotADirectoryError(
-            "Log directory does not exist: {}".format(str(log_dir.absolute()))
-        )
+    log_dir.mkdir(parents=True, exist_ok=True)
 
     jobname = get_job_name(job_properties)
-    out_log = str(log_dir / cluster.get("output", "{}.out".format(jobname)))
-    err_log = str(log_dir / cluster.get("error", "{}.err".format(jobname)))
+   
+    out_log = log_dir / cluster.get("output", "{}.out".format(jobname))
+    out_log_parent = out_log.parent
+    out_log_parent.mkdir(parents=True,	exist_ok=True)
+
+    err_log = log_dir / cluster.get("error", "{}.err".format(jobname))
+    err_log_parent = err_log.parent
+    err_log_parent.mkdir(parents=True,	exist_ok=True)
 
     return '-o "{out_log}" -e "{err_log}" -J "{jobname}"'.format(
         out_log=out_log, err_log=err_log, jobname=jobname

--- a/{{cookiecutter.profile_name}}/lsf-submit.py
+++ b/{{cookiecutter.profile_name}}/lsf-submit.py
@@ -72,11 +72,11 @@ def generate_jobinfo_command(job_properties: dict) -> str:
    
     out_log = log_dir / cluster.get("output", "{}.out".format(jobname))
     out_log_parent = out_log.parent
-    out_log_parent.mkdir(parents=True,	exist_ok=True)
+    out_log_parent.mkdir(parents=True, exist_ok=True)
 
     err_log = log_dir / cluster.get("error", "{}.err".format(jobname))
     err_log_parent = err_log.parent
-    err_log_parent.mkdir(parents=True,	exist_ok=True)
+    err_log_parent.mkdir(parents=True, exist_ok=True)
 
     return '-o "{out_log}" -e "{err_log}" -J "{jobname}"'.format(
         out_log=out_log, err_log=err_log, jobname=jobname


### PR DESCRIPTION
I've had issues with `/` in the wildcards when using this profile. Classic example is to make a rule to index fasta files, which is called everytime we need an index for a fasta in the pipeline, e.g.:

```
rule bwa_index:
    input:
        fasta = "{fasta}"
    output:
        indexed_fasta = "{fasta}.amb"
    threads: 1
    log: "{fasta}.bwa_index.log"
    resources:
        mem_mb = lambda wildcards, attempt: 4000 * 2**(attempt-1)
    shell:
        "bwa index {input.fasta} > {log} 2>&1"
```

An example of execution:
```
rule bwa_index:
    input: analysis/recall/variant_calls_probesets/sample/all/snippy_ref/coverage_filter_0/strand_bias_filter_Not_App/gaps_filter_Not_App/variant_calls_probeset.fa
    output: analysis/recall/variant_calls_probesets/sample/all/snippy_ref/coverage_filter_0/strand_bias_filter_Not_App/gaps_filter_Not_App/variant_calls_probeset.fa.amb
    log: analysis/recall/variant_calls_probesets/sample/all/snippy_ref/coverage_filter_0/strand_bias_filter_Not_App/gaps_filter_Not_App/variant_calls_probeset.fa.bwa_index.log
    jobid: 0
    wildcards: fasta=analysis/recall/variant_calls_probesets/sample/all/snippy_ref/coverage_filter_0/strand_bias_filter_Not_App/gaps_filter_Not_App/variant_calls_probeset.fa
    resources: mem_mb=1000
```

Snakemake will always fail to open the output and error cluster log files because the parent folder will never exist due to `/` being in one of the input params (having `/` in any of the input params will cause this). Note that it is the **cluster** log file, not the job log file (`analysis/recall/variant_calls_probesets/sample/all/snippy_ref/coverage_filter_0/strand_bias_filter_Not_App/gaps_filter_Not_App/variant_calls_probeset.fa.bwa_index.log`). In my cluster, I get a mail for each of such "failing" jobs (it does not fail the pipeline, exit status is still 0, but not being able to save the logs makes lsf send me a mail) where the tail is:
```
PS:

Fail to open output file logs/cluster/bwa_index.fasta=analysis/recall/variant_calls_probesets/sample/all/snippy_ref/coverage_filter_0/strand_bias_filter_Not_App/gaps_filter_Not_App/variant_calls_probeset.fa.out: No such file or directory.
Output is stored in this mail.
Fail to open stderr file logs/cluster/bwa_index.fasta=analysis/recall/variant_calls_probesets/sample/all/snippy_ref/coverage_filter_0/strand_bias_filter_Not_App/gaps_filter_Not_App/variant_calls_probeset.fa.err: No such file or directory.
The stderr output is included in this report.
```

This PR solves this issue by creating the parent directories for the output and error cluster log files before submitting the job.

A second thing it does is automatically creating the `"{{cookiecutter.default_cluster_logdir}}"` when the pipeline is run (instead of erroring out). Not sure if this behaviour is good or bad, but I've found myself many times forgetting to create the `logs/cluster` dir, and the pipeline failing, while it does not seem we create any issue by automatically creating this folder, instead of erroring out.

I tested this profile in a sample and a real pipeline, and it ran fine, but I am not sure the behaviour described in this PR is desirable for the lsf profile.