### PR TITLE
Specify memory units when submitting

### DIFF
--- a/tests/test_lsf_submit.py
+++ b/tests/test_lsf_submit.py
@@ -1,13 +1,13 @@
 import unittest
 from unittest.mock import patch
-from tests.src.lsf_submit import LSF_Submit, BsubInvocationError, JobidNotFoundError
+from tests.src.lsf_submit import Submitter, BsubInvocationError, JobidNotFoundError
 from tests.src.CookieCutter import CookieCutter
 from tests.src.OSLayer import OSLayer
 from pathlib import Path
 from subprocess import CalledProcessError
 
 
-class Test_LSF_Submit(unittest.TestCase):
+class TestSubmitter(unittest.TestCase):
     @patch.object(
         CookieCutter, CookieCutter.get_log_dir.__name__, return_value="logdir"
     )
@@ -26,7 +26,7 @@ class Test_LSF_Submit(unittest.TestCase):
             "cluster_opt_3",
             "real_jobscript.sh",
         ]
-        lsf_submit = LSF_Submit(argv)
+        lsf_submit = Submitter(argv)
         self.assertEqual(lsf_submit.jobscript, "real_jobscript.sh")
         self.assertEqual(
             lsf_submit.cluster_cmd, "cluster_opt_1 cluster_opt_2 cluster_opt_3"
@@ -87,7 +87,7 @@ class Test_LSF_Submit(unittest.TestCase):
             "cluster_opt_3",
             "real_jobscript.sh",
         ]
-        lsf_submit = LSF_Submit(argv)
+        lsf_submit = Submitter(argv)
         actual = lsf_submit._submit_cmd_and_get_external_job_id()
         expected = 8697223
         self.assertEqual(actual, expected)
@@ -113,7 +113,7 @@ class Test_LSF_Submit(unittest.TestCase):
             "cluster_opt_3",
             "real_jobscript.sh",
         ]
-        lsf_submit = LSF_Submit(argv)
+        lsf_submit = Submitter(argv)
         self.assertRaises(JobidNotFoundError, lsf_submit.submit)
 
     @patch.object(
@@ -152,7 +152,7 @@ class Test_LSF_Submit(unittest.TestCase):
             "cluster_opt_3",
             "real_jobscript.sh",
         ]
-        lsf_submit = LSF_Submit(argv)
+        lsf_submit = Submitter(argv)
 
         lsf_submit.submit()
 
@@ -200,7 +200,7 @@ class Test_LSF_Submit(unittest.TestCase):
             "cluster_opt_3",
             "real_jobscript.sh",
         ]
-        lsf_submit = LSF_Submit(argv)
+        lsf_submit = Submitter(argv)
 
         self.assertRaises(BsubInvocationError, lsf_submit.submit)
 

--- a/{{cookiecutter.profile_name}}/lsf_submit.py
+++ b/{{cookiecutter.profile_name}}/lsf_submit.py
@@ -47,7 +47,7 @@ class JobidNotFoundError(Exception):
     pass
 
 
-class LSF_Submit:
+class Submitter:
     def __init__(self, argv: List[str]):
         self._jobscript = argv[-1]
         self._cluster_cmd = " ".join(argv[1:-1])
@@ -205,5 +205,5 @@ class LSF_Submit:
 
 
 if __name__ == "__main__":
-    lsf_submit = LSF_Submit(sys.argv)
+    lsf_submit = Submitter(sys.argv)
     lsf_submit.submit()

--- a/{{cookiecutter.profile_name}}/lsf_submit.py
+++ b/{{cookiecutter.profile_name}}/lsf_submit.py
@@ -1,28 +1,4 @@
 #!/usr/bin/env python3
-"""
-lsf-submit.py
-
-Script to wrap bsub sync command for Snakemake. Uses the following job or
-cluster parameters:
-
-+ `threads`
-+ `resources`
-    - `mem_mb`: Expected memory requirements in megabytes. Overrides
-      cluster.mem_mb
-+ `cluster`
-    - `mem_mb`: Memory that will be requested for the cluster for the job.
-      Overriden by resources.mem_mb, if present.
-      `resources`
-    - `queue`: Which queue to run job on
-    - `logdir`: Where to log stdout/stderr from cluster command
-    - `output`: Name of stdout logfile
-    - `error`: Name of stderr logfile
-    - `jobname`: Job name (with wildcards)
-
-Author: Michael B Hall
-Adapted from: https://github.com/jaicher/snakemake-sync-bq-sub
-"""
-
 import sys
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
Addresses the issue raised in #9 where some clusters may not have MB set as their default units. We explicitly use MB when submitting to avoid this.

This is submitted as a separate PR to #9 because I had some issues trying to add commits to that PR (my own lack of technical ability).