### PR TITLE
Robust memory unit handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,30 @@ cookiecutter --output-dir "$profile_dir" "$template"
 
 You will then be prompted to set some default parameters.
 
+#### `LSF_UNIT_FOR_LIMITS`
+
+**Default**: `KB`  
+**Valid options:** `KB`, `MB`, `GB`, `TB`, `PB`, `EB`, `ZB`
+
+**⚠️IMPORTANT⚠️**: This **must** be set to the same as [`LSF_UNIT_FOR_LIMITS`][limits] on
+your cluster. This value is stored in your cluster's [`lsf.conf`][lsf-conf] file. In
+general, this file is located at `${LSF_ENVDIR}/lsf.conf`. So the easiest way to get
+this value is to run the following:
+
+```shell
+grep '^LSF_UNIT_FOR_LIMITS' ${LSF_ENVDIR}/lsf.conf
+```
+
+You should get something along the lines of `LSF_UNIT_FOR_LIMITS=MB`. If this command
+doesn't work, get in touch with your cluster administrator to find out the value.
+
+As mentioned above, this is a very important parameter. It sets the scaling units to use
+for resource limits. So, if this value is `MB` on your cluster, then when setting the
+memory limit with `-M 1000` the value is taken as megabytes. As `snakemake` allows you
+to set the memory for a rule with the `resources: mem_mb` parameter, it is important for
+this profile to know whether this then needs to be converted into other units when
+submitting jobs. See [here][18] for further information.
+
 #### `latency_wait`
 
 **Default:** `5`
@@ -65,9 +89,7 @@ From the `snakemake --help` menu
 #### `use_conda`
 
 **Default**: `False`  
-**Valid options:**
-- `False`
-- `True`
+**Valid options:** `False`, `True`
 
 This sets the default `--use-conda` parameter in `snakemake`.  
 From the `snakemake --help` menu
@@ -82,9 +104,7 @@ From the `snakemake --help` menu
 #### `use_singularity`
 
 **Default**: `False`  
-**Valid options:**
-- `False`
-- `True`
+**Valid options:** `False`, `True`
 
 This sets the default `--use-singularity` parameter in `snakemake`.  
 From the `snakemake --help` menu
@@ -111,9 +131,7 @@ From the `snakemake --help` menu
 #### `print_shell_commands`
 
 **Default**: `False`  
-**Valid options:**
-- `False`
-- `True`
+**Valid options:** `False`, `True`
 
 This sets the default ` --printshellcmds/-p` parameter in `snakemake`.  
 From the `snakemake --help` menu
@@ -359,3 +377,7 @@ Please refer to [`CONTRIBUTING.md`](CONTRIBUTING.md).
 [config-deprecate]: https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html#cluster-configuration-deprecated
 [yaml-collections]: https://yaml.org/spec/1.2/spec.html#id2759963
 [status-checker]: https://github.com/Snakemake-Profiles/snakemake-lsf/blob/master/%7B%7Bcookiecutter.profile_name%7D%7D/lsf_status.py
+[limits]: https://www.ibm.com/support/knowledgecenter/en/SSWRJV_10.1.0/lsf_config_ref/lsf.conf.lsf_unit_for_limits.5.html
+[lsf-conf]: https://www.ibm.com/support/knowledgecenter/en/SSETD4_9.1.2/lsf_config_ref/lsf.conf.5.html
+[18]: https://github.com/Snakemake-Profiles/snakemake-lsf/issues/18
+

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+  "LSF_UNIT_FOR_LIMITS": ["KB", "MB", "GB", "TB", "PB", "EB", "ZB"],
   "latency_wait": 5,
   "use_conda": false,
   "use_singularity": false,

--- a/tests/test_memory_units.py
+++ b/tests/test_memory_units.py
@@ -1,0 +1,346 @@
+import pytest
+
+from tests.src.memory_units import Unit, InvalidSuffix, InvalidPower, Memory, InvalidMemoryString
+
+
+class TestUnitFromSuffix:
+    def test_from_b_returns_bytes(self):
+        suffix = "B"
+
+        actual = Unit.from_suffix(suffix)
+        expected = Unit.BYTES
+
+        assert actual == expected
+
+    def test_from_gb_returns_giga(self):
+        suffix = "GB"
+
+        actual = Unit.from_suffix(suffix)
+        expected = Unit.GIGA
+
+        assert actual == expected
+
+    def test_from_lowercase_mb_returns_mega(self):
+        suffix = "mb"
+
+        actual = Unit.from_suffix(suffix)
+        expected = Unit.MEGA
+
+        assert actual == expected
+
+    def test_invalid_suffix_raises_error(self):
+        suffix = "OB"
+
+        with pytest.raises(InvalidSuffix) as error:
+            Unit.from_suffix(suffix)
+
+        assert error.match("Valid suffixes are")
+
+
+class TestUnitFromPower:
+    def test_from_1_returns_kilo(self):
+        power = 1
+
+        actual = Unit.from_power(power)
+        expected = Unit.KILO
+
+        assert actual == expected
+
+    def test_from_invalid_power_raises_error(self):
+        power = 10
+
+        with pytest.raises(InvalidPower) as error:
+            Unit.from_power(power)
+
+        assert error.match("Valid powers are")
+
+
+# some trivial getter tests
+def test_memory_power():
+    mem = Memory(3, Unit.MEGA)
+
+    actual = mem.power
+    expected = 2
+
+    assert actual == expected
+
+
+def test_memory_suffix():
+    mem = Memory(3, Unit.EXA)
+
+    actual = mem.suffix
+    expected = "EB"
+
+    assert actual == expected
+
+
+class TestMemoryBytes:
+    def test_memory_is_bytes_no_conversion_needed(self):
+        value = 40
+        mem = Memory(value)
+
+        actual = mem.bytes()
+        expected = value
+
+        assert actual == expected
+
+    def test_memory_is_megabytes_conversion_needed(self):
+        value = 40
+        unit = Unit.MEGA
+        mem = Memory(value, unit)
+
+        actual = mem.bytes()
+        expected = 40000000
+
+        assert actual == expected
+
+    def test_memory_is_kilobytes_nondecimal_returns_power_of_two(self):
+        value = 40
+        unit = Unit.KILO
+        mem = Memory(value, unit)
+
+        actual = mem.bytes(decimal_multiples=False)
+        expected = 40960
+
+        assert actual == expected
+
+    def test_memory_is_bytes_nondecimal_no_conversion_needed(self):
+        value = 50
+        mem = Memory(value)
+
+        actual = mem.bytes()
+        expected = value
+
+        assert actual == expected
+
+    def test_float_as_value(self):
+        value = 0.5
+        unit = Unit.GIGA
+        mem = Memory(value, unit)
+
+        actual = mem.bytes()
+        expected = 500000000
+
+        assert actual == expected
+
+    def test_large_floats_comparison(self):
+        value = 500
+        unit = Unit.ZETTA
+        mem = Memory(value, unit)
+
+        actual = mem.bytes()
+        expected = float(500000000000000000000000)
+
+        assert actual == expected
+
+
+class TestRepr:
+    def test_round_number_returns_int(self):
+        memory = Memory(50, Unit.KILO)
+
+        actual = str(memory)
+        expected = "50KB"
+
+        assert actual == expected
+
+    def test_round_float_number_returns_int(self):
+        memory = Memory(50.0, Unit.KILO)
+
+        actual = str(memory)
+        expected = "50KB"
+
+        assert actual == expected
+
+    def test_float_number_returns_float(self):
+        memory = Memory(50.2, Unit.ZETTA)
+
+        actual = str(memory)
+        expected = "50.2ZB"
+
+        assert actual == expected
+
+
+class TestMemoryEquality:
+    def test_same_value_and_unit(self):
+        value = 50
+        unit = Unit.PETA
+        mem1 = Memory(value, unit)
+        mem2 = Memory(value, unit)
+
+        assert mem1 == mem2
+
+    def test_same_value_different_unit(self):
+        value = 50
+        unit1 = Unit.PETA
+        mem1 = Memory(value, unit1)
+        unit2 = Unit.KILO
+        mem2 = Memory(value, unit2)
+
+        assert mem1 != mem2
+
+    def test_different_value_same_unit(self):
+        value1 = 50
+        unit = Unit.PETA
+        mem1 = Memory(value1, unit)
+        value2 = 60
+        mem2 = Memory(value2, unit)
+
+        assert mem1 != mem2
+
+    def test_different_value_different_unit_same_bytes(self):
+        mem1 = Memory(500, Unit.MEGA)
+        mem2 = Memory(0.5, Unit.GIGA)
+
+        assert mem1 == mem2
+
+    def test_different_value_different_unit_different_bytes(self):
+        mem1 = Memory(500, Unit.KILO)
+        mem2 = Memory(0.5, Unit.GIGA)
+
+        assert mem1 != mem2
+
+
+class TestMemoryTo:
+    def test_bytes_to_bytes(self):
+        memory = Memory(10)
+        desired_units = Unit.BYTES
+
+        actual = memory.to(desired_units)
+        expected = Memory(10, desired_units)
+
+        assert actual == expected
+
+    def test_bytes_to_kilobytes(self):
+        memory = Memory(10)
+        desired_units = Unit.KILO
+
+        actual = memory.to(desired_units)
+        expected = Memory(0.01, desired_units)
+
+        assert actual == expected
+
+    def test_bytes_to_megabytes(self):
+        memory = Memory(2500)
+        desired_units = Unit.MEGA
+
+        actual = memory.to(desired_units)
+        expected = Memory(0.0025, desired_units)
+
+        assert actual == expected
+
+    def test_kilobytes_to_gigabytes(self):
+        memory = Memory(2500, Unit.KILO)
+        desired_units = Unit.GIGA
+
+        actual = memory.to(desired_units)
+        expected = Memory(0.0025, desired_units)
+
+        assert actual == expected
+
+    def test_terabytes_to_megabytes(self):
+        memory = Memory(30, Unit.TERA)
+        desired_units = Unit.MEGA
+
+        actual = memory.to(desired_units)
+        expected = Memory(30000000, desired_units)
+
+        assert actual == expected
+
+    def test_terabytes_to_kilobytes_in_binary(self):
+        memory = Memory(30, Unit.TERA)
+        desired_units = Unit.KILO
+
+        actual = memory.to(desired_units, decimal_multiples=False)
+        expected = Memory(32212254720, desired_units)
+
+        assert actual == expected
+
+
+class TestMemoryFromStr:
+    def test_empty_string_raises_error(self):
+        s = ""
+
+        with pytest.raises(InvalidMemoryString):
+            Memory.from_str(s)
+
+    def test_no_suffix_returns_bytes(self):
+        s = "500"
+
+        actual = Memory.from_str(s)
+        expected = Memory(500)
+
+        assert actual == expected
+
+    def test_no_suffix_and_float_returns_bytes(self):
+        s = "500.8"
+
+        actual = Memory.from_str(s)
+        expected = Memory(500.8)
+
+        assert actual == expected
+
+    def test_single_letter_suffix_is_valid(self):
+        s = "500M"
+
+        actual = Memory.from_str(s)
+        expected = Memory(500, Unit.MEGA)
+
+        assert actual == expected
+
+    def test_b_suffix_is_valid(self):
+        s = "500MB"
+
+        actual = Memory.from_str(s)
+        expected = Memory(500, Unit.MEGA)
+
+        assert actual == expected
+
+    def test_space_between_size_and_suffix_is_valid(self):
+        s = "500 MB"
+
+        actual = Memory.from_str(s)
+        expected = Memory(500, Unit.MEGA)
+
+        assert actual == expected
+
+    def test_multiple_spaces_between_size_and_suffix_is_valid(self):
+        s = "500  MB"
+
+        actual = Memory.from_str(s)
+        expected = Memory(500, Unit.MEGA)
+
+        assert actual == expected
+
+    def test_suffix_is_case_insensitive(self):
+        s = "500zb"
+
+        actual = Memory.from_str(s).bytes()
+        expected = Memory(500, Unit.ZETTA).bytes()
+
+        assert actual == expected
+
+    def test_suffix_only_raises_error(self):
+        s = "TB"
+
+        with pytest.raises(InvalidMemoryString):
+            Memory.from_str(s)
+
+    def test_bytes_suffix_is_valid(self):
+        s = "7B"
+
+        actual = Memory.from_str(s)
+        expected = Memory(7)
+
+        assert actual == expected
+
+    def test_invalid_suffix_raises_error(self):
+        s = "7LB"
+
+        with pytest.raises(InvalidMemoryString):
+            Memory.from_str(s)
+
+    def test_string_with_other_characters_raises_error(self):
+        s = "7KBY"
+
+        with pytest.raises(InvalidMemoryString):
+            Memory.from_str(s)

--- a/tests/test_memory_units.py
+++ b/tests/test_memory_units.py
@@ -1,6 +1,12 @@
 import pytest
 
-from tests.src.memory_units import Unit, InvalidSuffix, InvalidPower, Memory, InvalidMemoryString
+from tests.src.memory_units import (
+    Unit,
+    InvalidSuffix,
+    InvalidPower,
+    Memory,
+    InvalidMemoryString,
+)
 
 
 class TestUnitFromSuffix:

--- a/{{cookiecutter.profile_name}}/CookieCutter.py
+++ b/{{cookiecutter.profile_name}}/CookieCutter.py
@@ -18,3 +18,7 @@ class CookieCutter:
     @staticmethod
     def get_default_queue() -> str:
         return "{{cookiecutter.default_queue}}"
+
+    @staticmethod
+    def get_lsf_unit_for_limits() -> str:
+        return "{{cookiecutter.LSF_UNIT_FOR_LIMITS}}"

--- a/{{cookiecutter.profile_name}}/lsf_submit.py
+++ b/{{cookiecutter.profile_name}}/lsf_submit.py
@@ -85,11 +85,11 @@ class Submitter:
     @property
     def resources_cmd(self) -> str:
         mem_in_clusters_units = self.mem_mb.to(self.memory_units)
-        value_to_submit = math.ceil(mem_in_clusters_units.value)
+        mem_value_to_submit = math.ceil(mem_in_clusters_units.value)
         return (
-            "-M {mem_mb} -n {threads} "
-            "-R 'select[mem>{mem_mb}] rusage[mem={mem_mb}] span[hosts=1]'"
-        ).format(mem_mb=value_to_submit, threads=self.threads)
+            "-M {mem} -n {threads} "
+            "-R 'select[mem>{mem}] rusage[mem={mem}] span[hosts=1]'"
+        ).format(mem=mem_value_to_submit, threads=self.threads)
 
     @property
     def wildcards(self) -> dict:

--- a/{{cookiecutter.profile_name}}/lsf_submit.py
+++ b/{{cookiecutter.profile_name}}/lsf_submit.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
+import math
 import re
 import subprocess
 import sys
-from enum import Enum
 from pathlib import Path
 from typing import List, Union, Optional
 
@@ -13,10 +13,12 @@ if not __name__.startswith("tests.src."):
     from OSLayer import OSLayer
     from CookieCutter import CookieCutter
     from lsf_config import Config
+    from memory_units import Unit, Memory
 else:
     from .OSLayer import OSLayer
     from .CookieCutter import CookieCutter
     from .lsf_config import Config
+    from .memory_units import Unit, Memory
 
 PathLike = Union[str, Path]
 
@@ -29,26 +31,12 @@ class JobidNotFoundError(Exception):
     pass
 
 
-class MemoryUnits(Enum):
-    """See https://www.ibm.com/support/knowledgecenter/en/SSWRJV_10.1.0/lsf_command_ref/bsub.__r.1.html
-    for valid units.
-    """
-
-    KB = "KB"
-    MB = "MB"
-    GB = "GB"
-    TB = "TB"
-    PB = "PB"
-    EB = "EB"
-    ZB = "ZB"
-
-
 class Submitter:
     def __init__(
         self,
         jobscript: PathLike,
         cluster_cmds: List[str] = None,
-        memory_units: MemoryUnits = MemoryUnits.KB,
+        memory_units: Unit = Unit.MEGA,
         lsf_config: Optional[Config] = None,
     ):
         if cluster_cmds is None:
@@ -84,21 +72,24 @@ class Submitter:
         return self.job_properties.get("resources", dict())
 
     @property
-    def mem_mb(self) -> int:
-        return self.resources.get(
+    def mem_mb(self) -> Memory:
+        mem_value = self.resources.get(
             "mem_mb", self.cluster.get("mem_mb", CookieCutter.get_default_mem_mb())
         )
+        return Memory(mem_value, unit=Unit.MEGA)
 
     @property
-    def memory_units(self) -> str:
-        return self._memory_units.value
+    def memory_units(self) -> Unit:
+        return self._memory_units
 
     @property
     def resources_cmd(self) -> str:
+        mem_in_clusters_units = self.mem_mb.to(self.memory_units)
+        value_to_submit = math.ceil(mem_in_clusters_units.value)
         return (
-            "-M {mem_mb}{units} -n {threads} "
-            "-R 'select[mem>{mem_mb}{units}] rusage[mem={mem_mb}{units}] span[hosts=1]'"
-        ).format(mem_mb=self.mem_mb, threads=self.threads, units=self.memory_units)
+            "-M {mem_mb} -n {threads} "
+            "-R 'select[mem>{mem_mb}] rusage[mem={mem_mb}] span[hosts=1]'"
+        ).format(mem_mb=value_to_submit, threads=self.threads)
 
     @property
     def wildcards(self) -> dict:
@@ -236,7 +227,7 @@ if __name__ == "__main__":
 
     jobscript = sys.argv[-1]
     cluster_cmds = sys.argv[1:-1]
-    memory_units = MemoryUnits.MB
+    memory_units = Unit.from_suffix(CookieCutter.get_lsf_unit_for_limits())
     lsf_submit = Submitter(
         jobscript=jobscript,
         memory_units=memory_units,

--- a/{{cookiecutter.profile_name}}/memory_units.py
+++ b/{{cookiecutter.profile_name}}/memory_units.py
@@ -1,0 +1,140 @@
+import re
+from enum import Enum
+from typing import Union
+from collections import namedtuple
+
+
+class InvalidSuffix(Exception):
+    pass
+
+
+class InvalidPower(Exception):
+    pass
+
+
+class InvalidMemoryString(Exception):
+    pass
+
+
+Scale = namedtuple("Scale", ["power", "metric_suffix"])
+
+
+SCALE_MAP = {
+    "B": Scale(0, "B"),
+    "K": Scale(1, "KB"),
+    "M": Scale(2, "MB"),
+    "G": Scale(3, "GB"),
+    "T": Scale(4, "TB"),
+    "P": Scale(5, "PB"),
+    "E": Scale(6, "EB"),
+    "Z": Scale(7, "ZB"),
+}
+
+
+class Unit(Enum):
+    BYTES = SCALE_MAP["B"]
+    KILO = SCALE_MAP["K"]
+    MEGA = SCALE_MAP["M"]
+    GIGA = SCALE_MAP["G"]
+    TERA = SCALE_MAP["T"]
+    PETA = SCALE_MAP["P"]
+    EXA = SCALE_MAP["E"]
+    ZETTA = SCALE_MAP["Z"]
+
+    @staticmethod
+    def from_suffix(suffix: str) -> "Unit":
+        first_letter = suffix[0].upper()
+        if first_letter not in SCALE_MAP:
+            valid_suffixes = ",".join(
+                scale.metric_suffix for scale in SCALE_MAP.values()
+            )
+            raise InvalidSuffix(
+                "{suffix}. Valid suffixes are: {valid_suffixes}".format(
+                    suffix=suffix, valid_suffixes=valid_suffixes
+                )
+            )
+        return Unit(SCALE_MAP[first_letter])
+
+    @staticmethod
+    def from_power(power: int) -> "Unit":
+        valid_powers = []
+        for scale in SCALE_MAP.values():
+            if scale.power == power:
+                return Unit(scale)
+            valid_powers.append(scale.power)
+
+        raise InvalidPower(
+            "{power}. Valid powers are: {valid}".format(
+                power=power, valid=",".join(str(p) for p in valid_powers)
+            )
+        )
+
+    @property
+    def power(self) -> int:
+        return self.value.power
+
+    @property
+    def suffix(self) -> str:
+        return self.value.metric_suffix
+
+
+Number = Union[int, float]
+
+
+class Memory:
+    def __init__(self, value: Number = 1, unit: Unit = Unit.BYTES):
+        self.value = value
+        self.unit = unit
+        self._decimal_scaling_factor = 1000
+        self._binary_scaling_factor = 1024
+
+    def __eq__(self, other: "Memory") -> bool:
+        return self.bytes() == other.bytes()
+
+    def __repr__(self) -> str:
+        val = (
+            int(self.value)
+            if isinstance(self.value, int) or self.value.is_integer()
+            else self.value
+        )
+        return "{val}{sfx}".format(val=val, sfx=self.suffix)
+
+    @property
+    def power(self) -> int:
+        return self.unit.power
+
+    @property
+    def suffix(self) -> str:
+        return self.unit.suffix
+
+    def _scaling_factor(self, decimal: bool = True) -> int:
+        return self._decimal_scaling_factor if decimal else self._binary_scaling_factor
+
+    def bytes(self, decimal_multiples: bool = True) -> float:
+        scaling_factor = self._scaling_factor(decimal_multiples)
+        return float(self.value * (scaling_factor ** self.power))
+
+    def to(self, unit: Unit, decimal_multiples: bool = True) -> "Memory":
+        scaling_factor = self._scaling_factor(decimal_multiples) ** unit.power
+        size = self.bytes(decimal_multiples)
+        size /= scaling_factor
+
+        return Memory(size, unit)
+
+    @staticmethod
+    def from_str(s: str) -> "Memory":
+        valid_suffixes = "".join(scale.metric_suffix for scale in SCALE_MAP.values())
+        regex = re.compile(
+            r"^(?P<size>[0-9]*\.?[0-9]+)\s*(?P<sfx>[{}]B?)?$".format(valid_suffixes),
+            re.IGNORECASE,
+        )
+        match = regex.search(s)
+
+        if not match:
+            raise InvalidMemoryString("{s} is an invalid memory string.".format(s=s))
+
+        size = float(match.group("size"))
+        suffix = match.group("sfx") or "B"
+        unit = Unit.from_suffix(suffix)
+
+        return Memory(size, unit)


### PR DESCRIPTION
This PR addresses and closes #18 

It adds a `cookiecutter` option that asks the user for their cluster's `LSF_UNIT_FOR_LIMITS` value. Internally, it also adds my "headerless" [MemoryUnits](https://github.com/mbhall88/MemoryUnits) module for dealing with memory units and converting between different metric scales. See #18 for further information.