### PR TITLE
Better handling of group jobs

### DIFF
--- a/{{cookiecutter.profile_name}}/lsf_submit.py
+++ b/{{cookiecutter.profile_name}}/lsf_submit.py
@@ -104,7 +104,9 @@ class Submitter:
 
     @property
     def rule_name(self) -> str:
-        return self.job_properties.get("rule", "rule_name")
+        if not self.is_group_jobtype:
+            return self.job_properties.get("rule", "rule_name")
+        return self.groupid
 
     @property
     def groupid(self) -> str:
@@ -126,10 +128,10 @@ class Submitter:
         )
 
     @property
-    def jobid(self) -> int:
+    def jobid(self) -> str:
         if self.is_group_jobtype:
-            return int(self.job_properties.get("jobid", "").split("-")[0])
-        return int(self.job_properties.get("jobid"))
+            return self.job_properties.get("jobid", "").split("-")[0]
+        return str(self.job_properties.get("jobid"))
 
     @property
     def logdir(self) -> Path:


### PR DESCRIPTION
This PR closes #19 

We were casting job IDs to `int` when, in the case of group jobs, their ID is actually a UUID. I have changed this behaviour to return a `str` from the job ID method and also added 100% test coverage of all methods relating to group jobs.  

I have also tested this out on my cluster with a minimal group example [taken from the docs](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#defining-groups-for-execution).